### PR TITLE
fix ios 10 document click

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@
 <!-- Example: The page turns pink. -->
 
 ### Live Demo
-<!-- Example: https://jsbin.com/cagaye/edit?html,output -->
+<!-- Example: https://jsbin.com/jajawos/edit?html,output -->
 
 ### Steps to reproduce
 

--- a/shibui-dropdown-menu.html
+++ b/shibui-dropdown-menu.html
@@ -66,13 +66,17 @@ Example:
         }
       },
 
+      created: function () {
+        Polymer.Gestures.add(document.documentElement, 'tap', null);
+      },
+
       attached: function() {
         this._toggle = this._toggle.bind(this);
-        this._triggerElement.addEventListener('click', this._toggle);
+        this._triggerElement.addEventListener('tap', this._toggle);
       },
 
       detached: function() {
-        this._triggerElement.removeEventListener('click', this._toggle);
+        this._triggerElement.removeEventListener('tap', this._toggle);
       },
 
       /**

--- a/shibui-dropdown.html
+++ b/shibui-dropdown.html
@@ -111,6 +111,10 @@ Custom property | Description | Default
         }
       },
 
+      created: function () {
+        Polymer.Gestures.add(document.documentElement, 'tap', null);
+      },
+
       attached: function() {
         this.toggle = this.toggle.bind(this);
         this.open = this.open.bind(this);
@@ -118,7 +122,7 @@ Custom property | Description | Default
       },
 
       detached: function() {
-        document.removeEventListener('click', this.close);
+        document.removeEventListener('tap', this.close);
       },
 
       /**
@@ -145,10 +149,10 @@ Custom property | Description | Default
       _openedChanged: function(opened) {
         if (opened) {
           Polymer.RenderStatus.afterNextRender(this, function() {
-            document.addEventListener('click', this.close);
+            document.addEventListener('tap', this.close);
           });
         } else {
-          document.removeEventListener('click', this.close);
+          document.removeEventListener('tap', this.close);
         }
       }
     });


### PR DESCRIPTION
iOS 10 Safari does not close the dropdown when you click on the document.
So we could use polymer's tap polyfill for iOS 10 compatibility.

[source](https://github.com/PolymerElements/iron-overlay-behavior/blob/086b930c548dea9a1ce777a154d859cb19e9df6e/iron-overlay-manager.html#L48)